### PR TITLE
Add endpoint for pulling order transactions

### DIFF
--- a/src/NovakSolutions/Infusionsoft/Model/Transaction.php
+++ b/src/NovakSolutions/Infusionsoft/Model/Transaction.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace NovakSolutions\Infusionsoft\Model;
+use NovakSolutions\Infusionsoft\Enum\FieldTypes;
+
+/**
+ * Class Transaction
+ * @package NovakSolutions\Infusionsoft\Model
+ * @property int $id
+ * @property float $amount
+ * @property string $collection_method
+ * @property int $contact_id
+ * @property string $currency
+ * @property string $errors
+ * @property string $gateway
+ * @property string $gateway_account_name
+ * @property string $order_ids
+ * @property string $paymentDate
+ * @property string $status
+ * @property boolean $test
+ * @property string $transaction_date
+ * @property string $type
+ */
+class Transaction extends Model
+{
+    protected static $fields = [
+        'id' => FieldTypes::INT,
+        'amount' => FieldTypes::FLOAT,
+        'collection_method' => FieldTypes::STRING,
+        'contact_id' => FieldTypes::INT,
+        'currency' => FieldTypes::STRING,
+        'errors' => FieldTypes::STRING,
+        'gateway' => FieldTypes::STRING,
+        'gateway_account_name' => FieldTypes::STRING,
+        'order_ids' => FieldTypes::STRING,
+        'paymentDate' => FieldTypes::STRING,
+        'status' => FieldTypes::STRING,
+        'test' => FieldTypes::BOOL,
+        'transaction_date' => FieldTypes::STRING,
+        'type' => FieldTypes::STRING,
+    ];
+}

--- a/src/NovakSolutions/Infusionsoft/Service/OrderService.php
+++ b/src/NovakSolutions/Infusionsoft/Service/OrderService.php
@@ -40,4 +40,48 @@ class OrderService extends Service
 
         return true;
     }
+
+    public static function getOrderTransactions(
+        $orderId,
+        $limit = null,
+        $offset = null,
+        $since = null,
+        $until = null,
+        $accessToken = null
+    ) {
+        $url = static::$endPoint . '/' . $orderId . '/transactions';
+
+        // Prep query vars
+        $query = [];
+        if ($limit) {
+            $query['limit'] = $limit;
+        }
+        if ($offset) {
+            $query['offset'] = $offset;
+        }
+        if ($since) {
+            $query['since'] = $since;
+        }
+        if ($until) {
+            $query['until'] = $until;
+        }
+        if (count($query) > 0) {
+            $url .= '?' . http_build_query($query);
+        }
+
+        //Make Call...
+        /** @var WebRequestResult $result */
+        $result = Registry::$WebRequester->request($url, 'GET', [], $accessToken);
+        static::throwExceptionIfError($result);
+
+        $data = json_decode($result->body, true);
+        if(isset($data['transactions']) && is_array($data['transactions'])){
+            $objects = [];
+            foreach($data['transactions'] as $item){
+                $objects[] = new \NovakSolutions\Infusionsoft\Model\Transaction($item);
+            }
+            return $objects;
+        }
+        return [];
+    }
 }


### PR DESCRIPTION
I loaded this SDK branch into my Athena dev and hit the endpoint for an order that has known declined transactions.
The return data from the Rest API did include all of the declines and a definitive association between the decline and the affected order ids.

Infusionsoft will bundle charges for multiple orders on a single Contact into a single transaction, so it is possible for a transaction to link to more than one Order; the return data from Infusionsoft on this endpoint does include a string of order_ids associated with the transaction.

If you want to see this new endpoint in action, check out feature/update-infusionsoft-rest-api