### PR TITLE
Make implicitly-nullable constructor params explicit for PHP 8.4

### DIFF
--- a/src/NovakSolutions/Infusionsoft/Exception/BadRequestException.php
+++ b/src/NovakSolutions/Infusionsoft/Exception/BadRequestException.php
@@ -18,7 +18,7 @@ class BadRequestException extends Exception
      * BadRequestException constructor.
      * @param string $string
      */
-    public function __construct($string = null, $code = null, Throwable $previous = null)
+    public function __construct($string = null, $code = null, ?Throwable $previous = null)
     {
         parent::__construct($string, $code, $previous);
     }

--- a/src/NovakSolutions/Infusionsoft/Exception/UnAuthorizedException.php
+++ b/src/NovakSolutions/Infusionsoft/Exception/UnAuthorizedException.php
@@ -16,7 +16,7 @@ class UnAuthorizedException extends Exception
      * UnAuthorizedException constructor.
      * @param string $string
      */
-    public function __construct($string = null, $code = null, Throwable $previous = null)
+    public function __construct($string = null, $code = null, ?Throwable $previous = null)
     {
         parent::__construct($string, $code, $previous);
     }

--- a/src/NovakSolutions/Infusionsoft/Model/Model.php
+++ b/src/NovakSolutions/Infusionsoft/Model/Model.php
@@ -17,7 +17,7 @@ class Model
 
     protected $data = array();
 
-    public function __construct(array $data = null, $authTokenKey = '')
+    public function __construct(?array $data = null, $authTokenKey = '')
     {
          if($data != null){
              $this->fromArray($data);


### PR DESCRIPTION
PHP 8.4 deprecates 'Type $x = null' (implicit nullable) in favor of '?Type $x =
null'. Add the '?' to the typed, null-defaulted params:
- Model::__construct(?array $data)
- BadRequestException::__construct(..., ?Throwable $previous)
- UnAuthorizedException::__construct(..., ?Throwable $previous)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
